### PR TITLE
fix numerical stability and versioning

### DIFF
--- a/groupBMC.py
+++ b/groupBMC.py
@@ -123,7 +123,7 @@ class GroupBMC:
         partitions = [np.array([i]) for i in range(K)] if partitions is None else [np.array(p) - 1 for p in partitions]
         assert np.all(np.sort(np.concatenate(partitions)) == np.arange(K)), 'Invalid partition of the model space!'
         Nf = len(partitions)
-        self.families = np.zeros((K, Nf), dtype=np.bool)
+        self.families = np.zeros((K, Nf), dtype=bool)
         for j in range(Nf):
             self.families[partitions[j], j] = True
         self.α_0 = (self.families / self.families.sum(axis=0) @ (np.ones(Nf) / Nf) if α_0 is None else α_0)[:, None]

--- a/groupBMC.py
+++ b/groupBMC.py
@@ -141,7 +141,7 @@ class GroupBMC:
     
     def get_result(self) -> GroupBMCResult:
         """ Get various statistics of the posterior Dirichlet distribution on model frequencies. """
-        bor: float = 1 / (1 + exp(self.F1() - self.F0()))
+        bor: float = expit(self.F0() - self.F1())
         if self.families.size == 0:
             return GroupBMCResult(self.α.flatten(), self.z, bor)
         return GroupBMCResult(self.families.T @ self.α.flatten(), self.families.T @ self.z, bor)

--- a/groupBMC.py
+++ b/groupBMC.py
@@ -59,6 +59,8 @@ def exceedance_probability(distribution: rv_continuous, n_samples: Optional[int]
                         φ_i *= gammainc(α[j], x)
                 return φ_i * exp((α[i] - 1) * log(x) - x - γ[i])
             φ = [integrate.quad(lambda x: f(x, i), 0, np.inf)[0] for i in range(n)]
+            if sum(φ) == 0:
+                return exceedance_probability(distribution, n_samples=1000000)
         else:
             raise NotImplementedError('Numerical integration not implemented for this distribution!')
         φ = np.array(φ)

--- a/groupBMC.py
+++ b/groupBMC.py
@@ -11,6 +11,7 @@ https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2703732/pdf/ukmss-5226.pdf.
 __author__ = 'Sichao Yang'
 __contact__ = 'sichao@cs.wisc.edu'
 __license__ = 'MIT'
+__version__ = '1.0.1'
 
 
 from typing import List, Optional

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name="groupBMC",
+    version="1.0.1",
+    py_modules=["groupBMC"],
+    install_requires=[
+        "numpy",
+        "scipy",
+    ],
+)


### PR DESCRIPTION
- fixed `np.bool` deprecation that breaks after `np >= 1.24`
-  `1 / (1 + exp(x))` in BOR caused overflow with large `x`.  replaced with `scipy.special.expit`
- with extreme Dirichlet posteriors, we had `scipy.integrate.quad` return all 0s due to underflow. Now we have a fallback of doing Monte Carlo sampling with 1M samples.
-  added a minimal setup.py so the package can be installed via `pip install .`
- bumped version to 1.0.1